### PR TITLE
feature/civi-data-transformer

### DIFF
--- a/app/Transformers/CiviCrm/OrganisationTransformer.php
+++ b/app/Transformers/CiviCrm/OrganisationTransformer.php
@@ -12,6 +12,34 @@ class OrganisationTransformer
      */
     public function transform(Organisation $organisation): array
     {
-        return [];
+        return [
+            'name' => $organisation->name,
+            'description' => $organisation->description,
+            'email' => $organisation->email,
+            'url' => $organisation->url,
+            'phone' => $organisation->phone,
+            'address' => $this->transformAddress($organisation),
+        ];
+    }
+
+    /**
+     * @param \App\Models\Organisation $organisation
+     * @return string|null
+     */
+    protected function transformAddress(Organisation $organisation): ?string
+    {
+        $addressParts = [
+            $organisation->address_line_1,
+            $organisation->address_line_2,
+            $organisation->address_line_3,
+            $organisation->city,
+            $organisation->county,
+            $organisation->postcode,
+            $organisation->country,
+        ];
+
+        $addressParts = array_filter($addressParts);
+
+        return implode(', ', $addressParts) ?: null;
     }
 }

--- a/app/Transformers/CiviCrm/OrganisationTransformer.php
+++ b/app/Transformers/CiviCrm/OrganisationTransformer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Transformers\CiviCrm;
+
+use App\Models\Organisation;
+
+class OrganisationTransformer
+{
+    /**
+     * @param \App\Models\Organisation $organisation
+     * @return array
+     */
+    public function transform(Organisation $organisation): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/Transformers/CiviCrm/OrganisationTransformerTest.php
+++ b/tests/Unit/Transformers/CiviCrm/OrganisationTransformerTest.php
@@ -10,14 +10,50 @@ class OrganisationTransformerTest extends TestCase
 {
     public function test_transform_works()
     {
-        $organisation = factory(Organisation::class)->create();
+        $organisation = new Organisation([
+            'name' => 'Acme Org',
+            'description' => 'Lorem ipsum',
+            'email' => 'acme.org@example.com',
+            'url' => 'acme.example.com',
+            'phone' => '01130000000',
+            'address_line_1' => '1 Fake Street',
+            'city' => 'Leeds',
+            'postcode' => 'LS1 2AB',
+        ]);
 
         $transformer = new OrganisationTransformer();
         $results = $transformer->transform($organisation);
 
-        $this->assertEqualsCanonicalizing(
-            [],
-            $results
-        );
+        $this->assertEqualsCanonicalizing([
+            'name' => 'Acme Org',
+            'description' => 'Lorem ipsum',
+            'email' => 'acme.org@example.com',
+            'url' => 'acme.example.com',
+            'phone' => '01130000000',
+            'address' => '1 Fake Street, Leeds, LS1 2AB',
+        ], $results);
+    }
+
+    public function test_transform_works_with_no_address()
+    {
+        $organisation = new Organisation([
+            'name' => 'Acme Org',
+            'description' => 'Lorem ipsum',
+            'email' => 'acme.org@example.com',
+            'url' => 'acme.example.com',
+            'phone' => '01130000000',
+        ]);
+
+        $transformer = new OrganisationTransformer();
+        $results = $transformer->transform($organisation);
+
+        $this->assertEqualsCanonicalizing([
+            'name' => 'Acme Org',
+            'description' => 'Lorem ipsum',
+            'email' => 'acme.org@example.com',
+            'url' => 'acme.example.com',
+            'phone' => '01130000000',
+            'address' => null,
+        ], $results);
     }
 }

--- a/tests/Unit/Transformers/CiviCrm/OrganisationTransformerTest.php
+++ b/tests/Unit/Transformers/CiviCrm/OrganisationTransformerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Transformers\CiviCrm;
+
+use App\Models\Organisation;
+use App\Transformers\CiviCrm\OrganisationTransformer;
+use Tests\TestCase;
+
+class OrganisationTransformerTest extends TestCase
+{
+    public function test_transform_works()
+    {
+        $organisation = factory(Organisation::class)->create();
+
+        $transformer = new OrganisationTransformer();
+        $results = $transformer->transform($organisation);
+
+        $this->assertEqualsCanonicalizing(
+            [],
+            $results
+        );
+    }
+}


### PR DESCRIPTION
https://trello.com/c/8CJCrmJy/157-map-loop-to-civicrm-data-fields-applying-validation-rules

This PR is using transformation logic not tested with CiviCRM, as access is still needed. Any alterations to the transformation logic will be completed in a new PR.